### PR TITLE
Fix an issue where new sections would be deleted

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ export class TestHost extends LitElement {
     return html`
     <input type=text value="test.md"></input>
     <button id=load @click=${this.load}>Load</button>
-    <button id=save @click=${this.markDirty}>Save</button>
+    <button id=save @click=${this.markDirty}>Save</button>${this.dirty ? '*' : ''}
     <br>
     <md-block-render
       .block=${this.tree?.root}
@@ -92,11 +92,21 @@ export class TestHost extends LitElement {
   async markDirty() {
     this.dirty = true;
     if (this.pendingModifications++) return;
-    while (this.pendingModifications) {
-      this.pendingModifications = await 0;
+    while (true) {
+      const preIdle = this.pendingModifications;
+      await new Promise(resolve => requestIdleCallback(resolve));
+      // Wait for an idle period where there are no new modifications.
+      if (this.pendingModifications != preIdle) {
+        continue;
+      }
+      let preSave = this.pendingModifications;
       await this.save();
+      if (this.pendingModifications === preSave) {
+        this.pendingModifications = 0;
+        this.dirty = false;
+        return;
+      }
     }
-    this.dirty = false;
   }
   private async save() {
     if (!this.tree) return;
@@ -194,10 +204,18 @@ export class TestHost extends LitElement {
       newEndIndex,
     };
 
-    inline.node.viewModel.edit(edit);
-    // TODO: fix focus when edit mutates blocks
-    this.hostContext.focusNode = inline.node;
-    this.hostContext.focusOffset = newEndIndex;
+    const newNodes = inline.node.viewModel.edit(edit);
+    if (newNodes) {
+      normalizeTree(inline.node.viewModel.tree);
+      const prev = newNodes[0].viewModel.previousSibling || newNodes[0].viewModel.parent!;
+      const next = findNextDfs(
+          prev,
+          ({type}) => ['paragraph', 'code-block', 'heading'].includes(type));
+      // TODO: is the focus offset always 0?
+      if (next) focusNode(this.hostContext, next, 0);
+    } else {
+      focusNode(this.hostContext, inline.node, newEndIndex);
+    }
   }
 }
 
@@ -513,6 +531,7 @@ function normalizeSection(node: ViewModelNode) {
         // Found a second heading, split out a new sibling section and move
         // all remaining children there.
         const newSection = node.viewModel.tree.import({type: 'section'});
+        newSection.viewModel.insertBefore(child.viewModel.parent!, child);
         child.viewModel.insertBefore(newSection);
         while (next) {
           const child = next;

--- a/src/markdown/view-model.ts
+++ b/src/markdown/view-model.ts
@@ -139,21 +139,26 @@ export class InlineViewModel extends ViewModel {
     };
 
     this.self.content = apply(this.self.content, result);
-    if (this.maybeReplaceWithBlocks()) return;
+    const newNodes = this.maybeReplaceWithBlocks();
+    if (newNodes) return newNodes;
     this.tree.observe.notify();
     this.inlineTree = this.inlineTree!.edit(result);
     this.inlineTree = inlineParser.parse(this.self.content, this.inlineTree);
     this.observe.notify();
+    return null;
   }
   private maybeReplaceWithBlocks() {
     const blocks = this.parseAsBlocks();
     if (!blocks) return false;
+    const newNodes: ViewModelNode[] = [];
     for (const child of blocks) {
       const node = this.tree.import<MarkdownNode>(child);
       node.viewModel.insertBefore(cast(this.parent), this.nextSibling);
+      newNodes.push(node);
+      
     }
     this.remove();
-    return true;
+    return newNodes;
   }
   private parseAsBlocks() {
     // TODO: Ensure there's a trailing new line.

--- a/test/specs/edit_test.ts
+++ b/test/specs/edit_test.ts
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {Main} from '../pages/main';
+import {testState} from '../util/test_state';
+
+describe('main', () => {
+  const state = testState(async () => {
+    const main = await new Main().load();
+    return {
+      main,
+      fs: await main.fileSystem
+    };
+  });
+  function inputOutputTest(input, output) {
+    return async () => {
+      const leading = /(\n +)/.exec(input)[1];
+      input = input.replace(new RegExp(leading, 'g'), '\n');
+      output = output.replace(new RegExp(leading, 'g'), '\n');
+      await state.main.opendirButton.click();
+      await browser.waitUntil(state.main.fileInput.isExisting);
+      await state.main.loadButton.click();
+      await browser.waitUntil($('>>>[contenteditable]').isExisting);
+      const inline = $('>>>[contenteditable]');
+      await inline.click();
+      await browser.keys(input.split(''));
+      await browser.waitUntil(state.main.isClean);
+      expect(await state.fs.getFile('test.md')).toEqual(output);
+    };
+  }
+  it('can generate multiple sections', inputOutputTest(
+    `# 1
+     a
+     # 2
+     b`,
+    `# 1
+     a
+     
+     # 2
+     b
+     `,
+  ));
+});


### PR DESCRIPTION
* normalize tree after edits that generate new blocks
* actually attach new sections to the tree during normalization
* focus the next editable node after edits that generate new blocks