### PR TITLE
tests: Try to make test startup more reliable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,5 +63,6 @@ jobs:
           chrome-version: stable
       - name: test
         run: |
-          npm run dev &
+          npm run serve &
+          sleep 5 &&
           npm run test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "serve": "web-dev-server --port 8001 --root-dir build",
     "dev": "concurrently -n tsc,wds \"tsc --watch --preserveWatchOutput\" \"npx web-dev-server --port 8001 --watch --root-dir build\"",
     "compile": "tsc",
     "build": "npm run compile && ./build-wasm.sh && cp index.html build/",

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -15,7 +15,7 @@
 import type { Options } from '@wdio/types'
 import * as os from 'os';
 
-const instances = Math.min(1, Math.round(os.cpus().length / 2));
+const instances = Math.max(1, Math.round(os.cpus().length / 2));
 export const config: Options.Testrunner = {
     autoCompileOpts: {
         autoCompile: true,
@@ -50,6 +50,7 @@ export const config: Options.Testrunner = {
     framework: 'jasmine',
     reporters: ['spec'],
     jasmineOpts: {
+        stopOnSpecFailure: true,
         defaultTimeoutInterval: 60000,
         //
         // The Jasmine framework allows interception of each assertion in order to log the state of the application


### PR DESCRIPTION
* Don't run `tsc` a second time
* Give `web-dev-server` a few seconds to start
* Set the CPU limit correctly, again
* Stop the run after the first spec fails