### PR TITLE
Fix cases where nodes were being reused

### DIFF
--- a/src/asserts.ts
+++ b/src/asserts.ts
@@ -14,13 +14,13 @@
 
 export function assert(val: unknown): asserts val {
   if (!val) {
-    throw new Error('assertion failed: ${val}');
+    throw new Error(`assertion failed: ${val}`);
   }
 }
 
 export function cast<T>(val: unknown): NonNullable<T> {
   if (val === null || val === undefined) {
-    throw new Error('cast failed: ${val}');
+    throw new Error(`cast failed: ${val}`);
   }
   return val as NonNullable<T>;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -559,6 +559,7 @@ function normalizeSection(node: ViewModelNode) {
     return true;
   }
   // The section did not have a heading, the children have been removed.
+  assert(!node.children || !node.children.length);
   node.viewModel.remove();
   return false;
 }

--- a/src/markdown/block-parser.ts
+++ b/src/markdown/block-parser.ts
@@ -40,12 +40,12 @@ const emptyParagraph: ParagraphNode = {
 
 const emptySection: MarkdownNode = {
   type: 'section',
-  children: [emptyParagraph],
+  children: [{...emptyParagraph}],
 };
 
 function ensureContent(
     children: MarkdownNode[],
-    result: MarkdownNode[] = [emptyParagraph]): MarkdownNode[] {
+    result: MarkdownNode[] = [{...emptyParagraph}]): MarkdownNode[] {
   if (children.length) return children;
   return result;
 }
@@ -56,7 +56,7 @@ function convertNode(node: Parser.SyntaxNode): MarkdownNode|undefined {
       return {
         type: 'document',
         children: ensureContent(
-            [...convertNodes(node.namedChildren)], [emptySection]),
+            [...convertNodes(node.namedChildren)], [{...emptySection}]),
       };
     case 'section':
       return {
@@ -75,7 +75,10 @@ function convertNode(node: Parser.SyntaxNode): MarkdownNode|undefined {
       };
     case 'list_item': {
       const children = node.namedChildren;
-      const marker = children[0].text;
+      let marker = children[0].text;
+      if (!marker.endsWith(' ')) {
+        marker += ' ';
+      }
       return {
         type: 'list-item',
         marker,

--- a/src/markdown/view-model.ts
+++ b/src/markdown/view-model.ts
@@ -202,8 +202,10 @@ export class MarkdownTree {
   ) {
     const result = node as T&ViewModelNode;
     if (result.type === 'paragraph' || result.type === 'heading' || result.type === 'code-block') {
+      assert(!result.viewModel);
       result.viewModel = new InlineViewModel(result, this, parent, childIndex);
     } else {
+      assert(!result.viewModel);
       result.viewModel = new ViewModel(result, this, parent, childIndex);
     }
     if (result.children) {

--- a/test/specs/edit_test.ts
+++ b/test/specs/edit_test.ts
@@ -51,4 +51,12 @@ describe('main', () => {
      b
      `,
   ));
+  it('can generate a list', inputOutputTest(
+    // TODO: require a space after '*' to generate a new list
+    `*a
+     b`,
+    `* a
+     * b
+     `,
+  ));
 });


### PR DESCRIPTION
This was causing these nodes to gain a second viewModel which resulted in many other failures.