### PR TITLE
Deflake tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         uses: pnpm/action-setup@v3.0.0
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
       - name: Cache build
         id: cache-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
           sleep 5 &&
           CHROMIUM_BIN=$(which chrome) pnpm run test
       - name: 'Upload test logs'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,13 @@ jobs:
           persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@v3.0.0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
       - name: Cache build
         id: cache-build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: build-${{ hashFiles('pnpm-lock.json', 'build-wasm.sh') }}
           path: build

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "vite": "^5.2.11",
-    "wdio-chromedriver-service": "^8.1.1",
     "web-tree-sitter": "^0.22.6",
     "webdriverio": "^8.24.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,9 +86,6 @@ importers:
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@20.12.8)
-      wdio-chromedriver-service:
-        specifier: ^8.1.1
-        version: 8.1.1(@wdio/types@8.36.1)(chromedriver@124.0.1)(webdriverio@8.36.1(typescript@5.4.5))
       web-tree-sitter:
         specifier: ^0.22.6
         version: 0.22.6
@@ -3251,19 +3248,6 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
-
-  wdio-chromedriver-service@8.1.1:
-    resolution: {integrity: sha512-pN3GiOkTIMnalfq4PJAHdX95pDp1orHnTY8W1fIbd6ok81ba97UjerTgS7lUDRUh1p0MAm35Ww0uc0/9wzB7SA==}
-    engines: {node: ^16.13 || >=18}
-    peerDependencies:
-      '@wdio/types': ^7.0.0 || ^8.0.0-alpha.219
-      chromedriver: '*'
-      webdriverio: ^7.0.0 || ^8.0.0-alpha.219
-    peerDependenciesMeta:
-      '@wdio/types':
-        optional: true
-      chromedriver:
-        optional: true
 
   web-component-analyzer@2.0.0:
     resolution: {integrity: sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==}
@@ -6710,19 +6694,6 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
-
-  wdio-chromedriver-service@8.1.1(@wdio/types@8.36.1)(chromedriver@124.0.1)(webdriverio@8.36.1(typescript@5.4.5)):
-    dependencies:
-      '@wdio/logger': 8.28.0
-      fs-extra: 11.2.0
-      split2: 4.2.0
-      tcp-port-used: 1.0.2
-      webdriverio: 8.36.1(typescript@5.4.5)
-    optionalDependencies:
-      '@wdio/types': 8.36.1
-      chromedriver: 124.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   web-component-analyzer@2.0.0:
     dependencies:

--- a/test/pages/main.ts
+++ b/test/pages/main.ts
@@ -31,6 +31,7 @@ export class Main extends Page {
   }
   async runCommand(command: string, argument?: string) {
     await browser.keys(control('p'));
+    await $('>>>dialog[open]').waitForExist();
     await browser.keys(command.split(''));
     await browser.keys('\n');
     // TODO: Does the component correctly buffer these keystrokes?
@@ -38,7 +39,7 @@ export class Main extends Page {
       await browser.keys(argument.split(''));
       await browser.keys('\n');
     }
-    await this.host.$('>>>dialog[open]').waitForExist({reverse: true});
+    await $('>>>dialog[open]').waitForExist({reverse: true});
   }
 }
 

--- a/test/pages/main.ts
+++ b/test/pages/main.ts
@@ -20,9 +20,9 @@ type Status = 'loading' | 'loaded' | 'error';
 export class Main extends Page {
   path = '/?no-default&debug';
   host = $('>>>pkm-editor');
+  dialog = $('>>>dialog[open]');
   isReady = this.host.shadow$('*').isExisting;
   fileSystem = new FileSystem();
-  isClean = async () => (await this.host.getAttribute('dirty')) === null;
   async status(...status: Status[]): Promise<Status> {
     await browser.waitUntil(async () =>
       status.includes((await this.host.getAttribute('status')) as Status),
@@ -33,10 +33,12 @@ export class Main extends Page {
     await browser.keys(control('p'));
     await browser.keys(command.split(''));
     await browser.keys('\n');
+    // TODO: Does the component correctly buffer these keystrokes?
     if (argument !== undefined) {
       await browser.keys(argument.split(''));
       await browser.keys('\n');
     }
+    await this.host.$('>>>dialog[open]').waitForExist({reverse: true});
   }
 }
 

--- a/test/specs/edit_test.ts
+++ b/test/specs/edit_test.ts
@@ -48,7 +48,6 @@ describe('main', () => {
   }
   async function checkExport(file: string, output: string) {
     output = removeLeadingWhitespace(output);
-    await browser.waitUntil(state.main.isClean);
     await state.main.runCommand('Export to OPFS');
     const contents = await state.fs.getFile(file);
     await state.fs.clear();
@@ -82,7 +81,6 @@ describe('main', () => {
            \`\`\`
            `,
       );
-      // TODO: does not wait for save
       await checkExport('transclusion.md', 'content\n');
     });
     it('can be inserted and deleted', async () => {

--- a/test/specs/roundtrip_test.ts
+++ b/test/specs/roundtrip_test.ts
@@ -23,7 +23,7 @@ describe('roundtrip parse/serialize', () => {
   });
   const state = testState(async () => {
     const main = await new Main().load();
-    return {main, fs: await main.fileSystem};
+    return {main, fs: main.fileSystem};
   });
   const roundtrip = (content: string) =>
     testRoundtrip(content, state.main, state.fs);

--- a/test/util/test_roundtrip.ts
+++ b/test/util/test_roundtrip.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import {FileSystem, Main} from '../pages/main';
-import {browser} from '@wdio/globals';
 
 export async function testRoundtrip(
   content: string,
@@ -28,7 +27,6 @@ export async function testRoundtrip(
   await main.runCommand('open', 'test');
   expect(await main.status('loaded', 'error')).toEqual('loaded');
   await main.runCommand('Export to OPFS');
-  await browser.waitUntil(main.isClean);
   const result = await fs.getFile('test.md');
   const resultv = removeWhitespace ? result.replace(/\s+/g, '') : result;
   const contentv = removeWhitespace ? content.replace(/\s+/g, '') : result;

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -16,8 +16,9 @@ import {browser} from '@wdio/globals';
 import type {Options} from '@wdio/types';
 import * as os from 'os';
 
-const instances = Math.max(1, Math.round(os.cpus().length / 2));
+const instances = Math.max(1, Math.round(os.cpus().length * 0.75));
 export const config: Options.Testrunner = {
+  runner: 'local',
   autoCompileOpts: {
     autoCompile: true,
     tsNodeOpts: {transpileOnly: true, project: 'test/tsconfig.json'},
@@ -27,7 +28,7 @@ export const config: Options.Testrunner = {
   maxInstances: instances,
   capabilities: [
     {
-      maxInstances: instances,
+      'wdio:maxInstances': instances,
       browserName: 'chrome',
       acceptInsecureCerts: true,
       'goog:chromeOptions': {
@@ -36,7 +37,6 @@ export const config: Options.Testrunner = {
       },
     },
   ],
-  // Level of logging verbosity: trace | debug | info | warn | error | silent
   logLevel: 'warn',
   outputDir: 'test/logs',
   bail: 0,
@@ -44,7 +44,7 @@ export const config: Options.Testrunner = {
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,
-  services: ['chromedriver'],
+  services: [],
   framework: 'jasmine',
   reporters: ['spec'],
   jasmineOpts: {


### PR DESCRIPTION
There was a race when we didn't wait for the command palette to close.

Also updates the way wdio loads chrome, the previous method using wdio-chromedriver-service was deprecated.